### PR TITLE
Add some missing Python keywords

### DIFF
--- a/Python.snippetshl
+++ b/Python.snippetshl
@@ -90,6 +90,22 @@
 			<string>try</string>
 			<string>except</string>
 			<string>str</string>
+			<string>and</string>
+			<string>elif</string>
+			<string>raise</string>
+			<string>exec</string>
+			<string>is</string>
+			<string>global</string>
+			<string>yield</string>
+			<string>break</string>
+			<string>finally</string>
+			<string>continue</string>
+			<string>del</string>
+			<string>pass</string>
+			<string>not</string>
+			<string>with</string>
+			<string>or</string>
+			<string>lambda</string>
 		</array>
 	</dict>
 </dict>


### PR DESCRIPTION
I noticed that some Python keywords (such as 'finally', 'elif', or 'lambda') is not highlight in Snippets App.  So I add all the missing keywords into the xml file.

The full list can be found here: http://docs.python.org/reference/lexical_analysis.html#keywords
