### PR TITLE
For Hadoop Pig DSL

### DIFF
--- a/Pig.snippetshl
+++ b/Pig.snippetshl
@@ -67,6 +67,7 @@
 			<string>copyFromLocal</string>
 			<string>copyToLocal</string>
 			<string>COUNT</string>
+			<string>COUNT_STAR</string>
 			<string>cp</string>
 			<string>cross</string>
 			<string>%declare</string>


### PR DESCRIPTION
The Hadoop Pig Keywords could be found at 
http://pig.apache.org/docs/r0.9.2/basic.html#reserved-keywords
